### PR TITLE
build: Run osmosisd directly

### DIFF
--- a/localosmosis/setup.sh
+++ b/localosmosis/setup.sh
@@ -219,29 +219,4 @@ then
     enable_cors
 fi
 
-osmosisd start --home $OSMOSIS_HOME &
-
-if [[ $STATE == 'true' ]]
-then
-    echo "Creating pools"
-
-    echo "uosmo / uusdc balancer"
-    create_two_asset_pool "uosmoUusdcBalancerPool.json"
-
-    echo "uosmo / uion balancer"
-    create_two_asset_pool "uosmoUionBalancerPool.json"
-
-    echo "uweth / uusdc stableswap"
-    create_stable_pool
-
-    echo "uusdc / uion balancer"
-    create_two_asset_pool "uusdcUionBalancerPool.json"
-
-    echo "stake / uion / uosmo balancer"
-    create_three_asset_pool
-
-    echo "uion / uosmo concentrated"
-    create_concentrated_pool
-    create_concentrated_pool_positions
-fi
-wait
+osmosisd start --home $OSMOSIS_HOME


### PR DESCRIPTION
The current setup had issues with docker where it would exit after 3 minutes. Running osmosisd as foreground process seems to have fixed the issue. Also removing things creating pool since those codepaths aren't anyway used (since $STATE is false by default).