### PR TITLE
feat: add --enable-bulk-memory option to the wasm-opt invocation

### DIFF
--- a/cosmwasm-optimizer/1539cd8-enable-bulk-memory.patch
+++ b/cosmwasm-optimizer/1539cd8-enable-bulk-memory.patch
@@ -1,0 +1,13 @@
+diff --git a/optimize.sh b/optimize.sh
+index ac7497f..07b4f09 100755
+--- a/optimize.sh
++++ b/optimize.sh
+@@ -46,7 +46,7 @@ for WASM in /target/wasm32-unknown-unknown/release/*.wasm; do
+ 
+   OUT_FILENAME=$(basename "$WASM")
+   echo "Optimizing $OUT_FILENAME ..."
+-  wasm-opt -Os "$WASM" -o "artifacts/$OUT_FILENAME"
++  wasm-opt -Os --enable-bulk-memory "$WASM" -o "artifacts/$OUT_FILENAME"
+ done
+ 
+ echo "Post-processing artifacts..."

--- a/cosmwasm-optimizer/build-image.sh
+++ b/cosmwasm-optimizer/build-image.sh
@@ -9,10 +9,13 @@ WORK_DIR=$(mktemp -d -p /tmp)
 
 git clone https://github.com/CosmWasm/optimizer "$WORK_DIR"
 
-patch_path="$(realpath 1539cd8-1.93.1.patch)"
+patch1_path="$(realpath 1539cd8-1.93.1.patch)"
+patch2_path="$(realpath 1539cd8-enable-bulk-memory.patch)"
+
 cd "$WORK_DIR"
 git checkout 1539cd865630d618df5246c35064078552194560 # v0.17.0
 
-git apply "${patch_path}"
+git apply "${patch1_path}"
+git apply "${patch2_path}"
 
 docker build -t "$IMAGE_NAME" .


### PR DESCRIPTION
After upgrading the toolchain from `1.86.0` to `1.93.1`, CosmWasm contract builds started producing wasm that includes bulk-memory instructions (`memory.copy`, `memory.fill`) in our build path.

Our optimizer step was invoking `wasm-opt -Os` without bulk-memory enabled, so optimization/validation failed with:

- `Bulk memory operations require bulk memory [--enable-bulk-memory]`

This change updates the optimizer invocation to include `--enable-bulk-memory`, so contract optimization succeeds with the new compiler output.

- `1.86.0` build output in our pipeline did not require bulk-memory validation support.
- `1.93.1` output does, so optimizer defaults are no longer sufficient.

- Build/CI optimization pipeline only
- No contract business-logic changes

- Produced artifacts may use bulk-memory wasm instructions.
- Target runtimes/chains must support this wasm feature; older runtimes may reject upload/execute.